### PR TITLE
Refactor reportWebVitals to improve performance metrics reporting

### DIFF
--- a/src/reportWebVitals.ts
+++ b/src/reportWebVitals.ts
@@ -1,14 +1,12 @@
-import type { ReportHandler } from 'web-vitals';
+import { onCLS, onINP, onLCP, onFCP, onTTFB, type Metric } from 'web-vitals';
 
-const reportWebVitals = (onPerfEntry?: ReportHandler) => {
-  if (onPerfEntry && onPerfEntry instanceof Function) {
-import('web-vitals').then(({ onCLS, onFID, onFCP, onLCP, onTTFB }) => {
-      onCLS(onPerfEntry);
-      onFID(onPerfEntry);
-      onFCP(onPerfEntry);
-      onLCP(onPerfEntry);
-      onTTFB(onPerfEntry);
-    });
+const reportWebVitals = (onPerfEntry?: (metric: Metric) => void) => {
+  if (onPerfEntry && typeof onPerfEntry === 'function') {
+    onCLS(onPerfEntry);
+    onINP(onPerfEntry); // replaces onFID
+    onFCP(onPerfEntry);
+    onLCP(onPerfEntry);
+    onTTFB(onPerfEntry);
   }
 };
 


### PR DESCRIPTION
This pull request updates the web vitals reporting logic in `src/reportWebVitals.ts` to use the latest recommended metrics and simplifies the import and usage pattern. The most important changes are:

**Metrics update:**

* Replaced the deprecated `onFID` metric with `onINP` to align with current web performance best practices. 

**Code simplification:**

* Changed the import statement to directly import required functions (`onCLS`, `onINP`, `onLCP`, `onFCP`, `onTTFB`) and the `Metric` type from `web-vitals`, removing the dynamic import.
* Updated the `reportWebVitals` function signature to use a callback that accepts a `Metric` object, and simplified the function type check. 