### PR TITLE
Update flight API endpoint for airport search functionality

### DIFF
--- a/src/Pages/flights.tsx
+++ b/src/Pages/flights.tsx
@@ -387,14 +387,15 @@ const NATIONALITIES = [
   "Zambian",
   "Zimbabwean",
 ];
+//https://wander-nest-ad3s.onrender.com/api/flights/airports/
 
 // Updated API Service Functions
 const flightAPI = {
   // Get airports for search autocomplete
   getAirports: async (search?: string): Promise<Airport[]> => {
     const url = search
-      ? `${API_BASE_URL}/airports/?search=${encodeURIComponent(search)}`
-      : `${API_BASE_URL}/airports/`;
+      ? `${API_BASE_URL}flights/airports/?search=${encodeURIComponent(search)}`
+      : `${API_BASE_URL}flights/airports/`;
 
     const response = await fetch(url);
     if (!response.ok) {


### PR DESCRIPTION
This pull request updates the API endpoint used to fetch airport data in the `flightAPI` service. The change ensures that all airport-related requests now use the correct `/flights/airports/` path, which aligns with the backend API structure.

API endpoint update:

* Updated the `getAirports` function in `src/Pages/flights.tsx` to use the `/flights/airports/` endpoint instead of `/airports/` for both default and search queries.